### PR TITLE
Tooltip über "Berechnen" button wenn Adresse oder Ausrichtung fehlen

### DIFF
--- a/pvtools/pages/index.vue
+++ b/pvtools/pages/index.vue
@@ -140,7 +140,7 @@
             <b-button-group class="mt-3">
               <b-button variant="primary" @click="generateData"
                 :disabled="(!adressData.lat && !adressData.lon) || input.roofs.length == 0"
-                :title="(!adressData.lat && !adressData.lon) || input.roofs.length == 0 ? 'Füge eine addresse und mindestens eine PV Ausrichtung hinzu' : ''"
+                :title="(!adressData.lat && !adressData.lon) || input.roofs.length == 0 ? 'Füge eine Adresse und mindestens eine PV Ausrichtung hinzu' : ''"
                 v-b-toggle.inputCollapse>
                 Berechnen
               </b-button>
@@ -151,18 +151,13 @@
             </b-button-group>
         
           <b-collapse id="extensionsCollapse">
-
-
-
             <b-form-group label="Speichergrößen:">
               <b-input-group append="Wh">
                 <b-form-tags input-id="tags-basic" v-model="inputBatterySizes" :tag-validator="tagValidator"
                   v-b-tooltip.hover title='Zwischen 0,2 und 200 kWh'
                   :input-attrs="{ 'aria-describedby': 'tags-validation-help' }"></b-form-tags>
-
               </b-input-group>
             </b-form-group>
-
             <b-form-group label="Vergleichsjahr:">
               <b-form-select v-model="input.year" :options="years"></b-form-select>
             </b-form-group>
@@ -222,9 +217,7 @@
                 <b-form-input v-model.number="input.linearSelfUseRateChange" type="number" min="-10" max="10" />
               </b-input-group>
             </b-form-group> -->
-            
           </b-collapse>
-
         </b-collapse>
       </b-col>
     </b-row>

--- a/pvtools/pages/index.vue
+++ b/pvtools/pages/index.vue
@@ -140,7 +140,7 @@
             <b-button-group class="mt-3">
               <b-button variant="primary" @click="generateData"
                 :disabled="(!adressData.lat && !adressData.lon) || input.roofs.length == 0"
-                v-if="disabled" v-tooltip="Füge eine addresse und mindestens eine PV Ausrichtung hinzu"
+                :title="isDisabled ? 'Füge eine addresse und mindestens eine PV Ausrichtung hinzu' : ''"
                 v-b-toggle.inputCollapse>
                 Berechnen
               </b-button>

--- a/pvtools/pages/index.vue
+++ b/pvtools/pages/index.vue
@@ -75,11 +75,10 @@
                 <b-input v-model.number="input.batteryCostsPerKwh" min="0" type="number" />
               </b-input-group>
             </b-form-group>
-
-
           </b-form>
         </b-collapse>
       </b-col>
+
       <b-col>
         <b-collapse id="inputCollapse" visible>
           <b-form @submit="addRoof" @submit.stop.prevent >
@@ -138,10 +137,10 @@
             </div>
           </b-list-group>
 
-
             <b-button-group class="mt-3">
               <b-button variant="primary" @click="generateData"
                 :disabled="(!adressData.lat && !adressData.lon) || input.roofs.length == 0"
+                v-if="disabled" v-tooltip="Füge eine addresse und mindestens eine PV Ausrichtung hinzu"
                 v-b-toggle.inputCollapse>
                 Berechnen
               </b-button>

--- a/pvtools/pages/index.vue
+++ b/pvtools/pages/index.vue
@@ -140,7 +140,7 @@
             <b-button-group class="mt-3">
               <b-button variant="primary" @click="generateData"
                 :disabled="(!adressData.lat && !adressData.lon) || input.roofs.length == 0"
-                :title="isDisabled ? 'Füge eine addresse und mindestens eine PV Ausrichtung hinzu' : ''"
+                :title="(!adressData.lat && !adressData.lon) || input.roofs.length == 0 ? 'Füge eine addresse und mindestens eine PV Ausrichtung hinzu' : ''"
                 v-b-toggle.inputCollapse>
                 Berechnen
               </b-button>


### PR DESCRIPTION
Wenn Adresse oder Ausrichtung fehlen hat der Berechnen button ein tooltip on hover. Wenn alles eingetragen ist ist der tooltip nicht mehr verfügbar.

Hab ich getestet indem ich temportär die Adressvalidierung deaktiviert habe (kann in der dev umgebung die adresse nicht auswählen [CORS fehler]).