### PR TITLE
Get rid of babel error for icons.js

### DIFF
--- a/pvtools/nuxt.config.js
+++ b/pvtools/nuxt.config.js
@@ -56,5 +56,6 @@ export default {
   // Build Configuration: https://go.nuxtjs.dev/config-build
 
   build: {
+    compact: true
   }
 }


### PR DESCRIPTION
Getting rid of "ERROR  [BABEL] Note: The code generator has deoptimised the styling of /app/node_modules/bootstrap-vue/src/icons/icons.js as it exceeds the max of 500KB."