### PR TITLE
Fix and simplification URL whitelisting

### DIFF
--- a/backend/api/relay.ts
+++ b/backend/api/relay.ts
@@ -2,7 +2,10 @@ import {RequestHandler} from "express";
 let axios = require("axios")
 
 export const relayAPIRequest:RequestHandler = ((req,res, next) => {
-    if (req.body.url == /((https?:\/\/)re\.jrc\.ec\.europa\.eu.+)|((https?:\/\/)nominatim\.openstreetmap\.org.+)/) return res.send(403)
+    if (!req.body.url.startsWith("https://re.jrc.ec.europa.eu/") &&
+	!req.body.url.startsWith("https://nominatim.openstreetmap.org/")) {
+        return res.send(403)
+    }
     if(req.body.method == "GET"){
         axios.get(req.body.url)
             .then((result:any) => res.json(result.data))


### PR DESCRIPTION
The old code was always false. So the intended whitelisting was not active. That code was also using a not eady to read RegEx. This was replaced with a better readable string comparison