### PR TITLE
Add Github action to ensure backend and frontend can still be built

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build_backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install dependencies
+        working-directory: backend
+        run: npm ci
+      - name: Compile TypeScript
+        working-directory: backend
+        run: npm run compile-ts
+
+  build_frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install dependencies
+        working-directory: pvtools
+        run: npm ci
+      # TODO: tests need to be fixed first
+      # - name: Run tests
+      #   working-directory: pvtools
+      #   run: npm run test-all
+      - name: Generate static frontend
+        working-directory: pvtools
+        run: npm run generate

--- a/pvtools/package.json
+++ b/pvtools/package.json
@@ -7,7 +7,8 @@
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
-    "test": "jest --watch"
+    "test": "jest --watch",
+    "test-all": "jest --all"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.5.1",


### PR DESCRIPTION
Umsetzung des Vorschlags aus #38. 
Wenn die Tests aus #30 behoben sind kann auch der zugehörige Code in der Action wieder aktiviert werden. Dann bekommt man mit wenn zukünftig ein Commit die Tests bricht.